### PR TITLE
feat: added mapstructure tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -776,9 +776,9 @@ func (g *schemaGenerator) generateStructType(
 		}
 
 		if isRequired {
-			structField.Tags = fmt.Sprintf(`json:"%s" yaml:"%s"`, name, name)
+			structField.Tags = fmt.Sprintf(`json:"%s" yaml:"%s" mapstructure:"%s"`, name, name, name)
 		} else {
-			structField.Tags = fmt.Sprintf(`json:"%s,omitempty" yaml:"%s,omitempty"`, name, name)
+			structField.Tags = fmt.Sprintf(`json:"%s,omitempty" yaml:"%s,omitempty" mapstructure:"%s,omitempty"`, name, name, name)
 		}
 
 		if structField.Comment == "" {

--- a/tests/data/core/4.2.1_array.go.output
+++ b/tests/data/core/4.2.1_array.go.output
@@ -7,28 +7,28 @@ import "encoding/json"
 
 type A421Array struct {
 	// MyArray corresponds to the JSON schema field "myArray".
-	MyArray []interface{} `json:"myArray,omitempty" yaml:"myArray,omitempty"`
+	MyArray []interface{} `json:"myArray,omitempty" yaml:"myArray,omitempty" mapstructure:"myArray,omitempty"`
 
 	// MyBooleanArray corresponds to the JSON schema field "myBooleanArray".
-	MyBooleanArray []bool `json:"myBooleanArray,omitempty" yaml:"myBooleanArray,omitempty"`
+	MyBooleanArray []bool `json:"myBooleanArray,omitempty" yaml:"myBooleanArray,omitempty" mapstructure:"myBooleanArray,omitempty"`
 
 	// MyIntegerArray corresponds to the JSON schema field "myIntegerArray".
-	MyIntegerArray []int `json:"myIntegerArray,omitempty" yaml:"myIntegerArray,omitempty"`
+	MyIntegerArray []int `json:"myIntegerArray,omitempty" yaml:"myIntegerArray,omitempty" mapstructure:"myIntegerArray,omitempty"`
 
 	// MyNestedNullArray corresponds to the JSON schema field "myNestedNullArray".
-	MyNestedNullArray [][]interface{} `json:"myNestedNullArray,omitempty" yaml:"myNestedNullArray,omitempty"`
+	MyNestedNullArray [][]interface{} `json:"myNestedNullArray,omitempty" yaml:"myNestedNullArray,omitempty" mapstructure:"myNestedNullArray,omitempty"`
 
 	// MyNullArray corresponds to the JSON schema field "myNullArray".
-	MyNullArray []interface{} `json:"myNullArray,omitempty" yaml:"myNullArray,omitempty"`
+	MyNullArray []interface{} `json:"myNullArray,omitempty" yaml:"myNullArray,omitempty" mapstructure:"myNullArray,omitempty"`
 
 	// MyNumberArray corresponds to the JSON schema field "myNumberArray".
-	MyNumberArray []float64 `json:"myNumberArray,omitempty" yaml:"myNumberArray,omitempty"`
+	MyNumberArray []float64 `json:"myNumberArray,omitempty" yaml:"myNumberArray,omitempty" mapstructure:"myNumberArray,omitempty"`
 
 	// MyObjectArray corresponds to the JSON schema field "myObjectArray".
-	MyObjectArray []A421ArrayMyObjectArrayElem `json:"myObjectArray,omitempty" yaml:"myObjectArray,omitempty"`
+	MyObjectArray []A421ArrayMyObjectArrayElem `json:"myObjectArray,omitempty" yaml:"myObjectArray,omitempty" mapstructure:"myObjectArray,omitempty"`
 
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
-	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty"`
+	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty" mapstructure:"myStringArray,omitempty"`
 }
 
 type A421ArrayMyObjectArrayElem map[string]interface{}

--- a/tests/data/core/nullableType.go.output
+++ b/tests/data/core/nullableType.go.output
@@ -10,10 +10,10 @@ type IntegerThing *int
 
 type NullableType struct {
 	// MyInlineStringValue corresponds to the JSON schema field "MyInlineStringValue".
-	MyInlineStringValue *string `json:"MyInlineStringValue,omitempty" yaml:"MyInlineStringValue,omitempty"`
+	MyInlineStringValue *string `json:"MyInlineStringValue,omitempty" yaml:"MyInlineStringValue,omitempty" mapstructure:"MyInlineStringValue,omitempty"`
 
 	// MyStringValue corresponds to the JSON schema field "MyStringValue".
-	MyStringValue StringThing `json:"MyStringValue,omitempty" yaml:"MyStringValue,omitempty"`
+	MyStringValue StringThing `json:"MyStringValue,omitempty" yaml:"MyStringValue,omitempty" mapstructure:"MyStringValue,omitempty"`
 }
 
 type StringThing *string

--- a/tests/data/core/object.go.output
+++ b/tests/data/core/object.go.output
@@ -7,7 +7,7 @@ import "encoding/json"
 
 type ObjectMyObject struct {
 	// MyString corresponds to the JSON schema field "myString".
-	MyString string `json:"myString" yaml:"myString"`
+	MyString string `json:"myString" yaml:"myString" mapstructure:"myString"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -30,5 +30,5 @@ func (j *ObjectMyObject) UnmarshalJSON(b []byte) error {
 
 type Object struct {
 	// MyObject corresponds to the JSON schema field "myObject".
-	MyObject *ObjectMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty"`
+	MyObject *ObjectMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty" mapstructure:"myObject,omitempty"`
 }

--- a/tests/data/core/objectEmpty.go.output
+++ b/tests/data/core/objectEmpty.go.output
@@ -4,7 +4,7 @@ package test
 
 type ObjectEmpty struct {
 	// Foo corresponds to the JSON schema field "foo".
-	Foo ObjectEmptyFoo `json:"foo,omitempty" yaml:"foo,omitempty"`
+	Foo ObjectEmptyFoo `json:"foo,omitempty" yaml:"foo,omitempty" mapstructure:"foo,omitempty"`
 }
 
 type ObjectEmptyFoo map[string]interface{}

--- a/tests/data/core/objectNested.go.output
+++ b/tests/data/core/objectNested.go.output
@@ -4,15 +4,15 @@ package test
 
 type ObjectNested struct {
 	// MyObject corresponds to the JSON schema field "myObject".
-	MyObject *ObjectNestedMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty"`
+	MyObject *ObjectNestedMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty" mapstructure:"myObject,omitempty"`
 }
 
 type ObjectNestedMyObject struct {
 	// MyObject corresponds to the JSON schema field "myObject".
-	MyObject *ObjectNestedMyObjectMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty"`
+	MyObject *ObjectNestedMyObjectMyObject `json:"myObject,omitempty" yaml:"myObject,omitempty" mapstructure:"myObject,omitempty"`
 }
 
 type ObjectNestedMyObjectMyObject struct {
 	// MyString corresponds to the JSON schema field "myString".
-	MyString *string `json:"myString,omitempty" yaml:"myString,omitempty"`
+	MyString *string `json:"myString,omitempty" yaml:"myString,omitempty" mapstructure:"myString,omitempty"`
 }

--- a/tests/data/core/primitives.go.output
+++ b/tests/data/core/primitives.go.output
@@ -7,19 +7,19 @@ import "encoding/json"
 
 type Primitives struct {
 	// MyBoolean corresponds to the JSON schema field "myBoolean".
-	MyBoolean *bool `json:"myBoolean,omitempty" yaml:"myBoolean,omitempty"`
+	MyBoolean *bool `json:"myBoolean,omitempty" yaml:"myBoolean,omitempty" mapstructure:"myBoolean,omitempty"`
 
 	// MyInteger corresponds to the JSON schema field "myInteger".
-	MyInteger *int `json:"myInteger,omitempty" yaml:"myInteger,omitempty"`
+	MyInteger *int `json:"myInteger,omitempty" yaml:"myInteger,omitempty" mapstructure:"myInteger,omitempty"`
 
 	// MyNull corresponds to the JSON schema field "myNull".
-	MyNull interface{} `json:"myNull,omitempty" yaml:"myNull,omitempty"`
+	MyNull interface{} `json:"myNull,omitempty" yaml:"myNull,omitempty" mapstructure:"myNull,omitempty"`
 
 	// MyNumber corresponds to the JSON schema field "myNumber".
-	MyNumber *float64 `json:"myNumber,omitempty" yaml:"myNumber,omitempty"`
+	MyNumber *float64 `json:"myNumber,omitempty" yaml:"myNumber,omitempty" mapstructure:"myNumber,omitempty"`
 
 	// MyString corresponds to the JSON schema field "myString".
-	MyString *string `json:"myString,omitempty" yaml:"myString,omitempty"`
+	MyString *string `json:"myString,omitempty" yaml:"myString,omitempty" mapstructure:"myString,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/core/ref.go.output
+++ b/tests/data/core/ref.go.output
@@ -4,13 +4,13 @@ package test
 
 type Ref struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 
 	// MyThing2 corresponds to the JSON schema field "myThing2".
-	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty"`
+	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty" mapstructure:"myThing2,omitempty"`
 }
 
 type Thing struct {
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }

--- a/tests/data/core/refExternalFile.go.output
+++ b/tests/data/core/refExternalFile.go.output
@@ -4,22 +4,22 @@ package test
 
 type Ref struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 
 	// MyThing2 corresponds to the JSON schema field "myThing2".
-	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty"`
+	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty" mapstructure:"myThing2,omitempty"`
 }
 
 type RefExternalFile struct {
 	// MyExternalThing corresponds to the JSON schema field "myExternalThing".
-	MyExternalThing *Thing `json:"myExternalThing,omitempty" yaml:"myExternalThing,omitempty"`
+	MyExternalThing *Thing `json:"myExternalThing,omitempty" yaml:"myExternalThing,omitempty" mapstructure:"myExternalThing,omitempty"`
 
 	// SomeOtherExternalThing corresponds to the JSON schema field
 	// "someOtherExternalThing".
-	SomeOtherExternalThing *Thing `json:"someOtherExternalThing,omitempty" yaml:"someOtherExternalThing,omitempty"`
+	SomeOtherExternalThing *Thing `json:"someOtherExternalThing,omitempty" yaml:"someOtherExternalThing,omitempty" mapstructure:"someOtherExternalThing,omitempty"`
 }
 
 type Thing struct {
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }

--- a/tests/data/core/refExternalFileWithDupe.go.output
+++ b/tests/data/core/refExternalFileWithDupe.go.output
@@ -4,26 +4,26 @@ package test
 
 type Ref struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing_1 `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing_1 `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 
 	// MyThing2 corresponds to the JSON schema field "myThing2".
-	MyThing2 *Thing_1 `json:"myThing2,omitempty" yaml:"myThing2,omitempty"`
+	MyThing2 *Thing_1 `json:"myThing2,omitempty" yaml:"myThing2,omitempty" mapstructure:"myThing2,omitempty"`
 }
 
 type RefExternalFileWithDupe struct {
 	// MyExternalThing corresponds to the JSON schema field "myExternalThing".
-	MyExternalThing *Thing_1 `json:"myExternalThing,omitempty" yaml:"myExternalThing,omitempty"`
+	MyExternalThing *Thing_1 `json:"myExternalThing,omitempty" yaml:"myExternalThing,omitempty" mapstructure:"myExternalThing,omitempty"`
 
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 }
 
 type Thing struct {
 	// Something corresponds to the JSON schema field "something".
-	Something *string `json:"something,omitempty" yaml:"something,omitempty"`
+	Something *string `json:"something,omitempty" yaml:"something,omitempty" mapstructure:"something,omitempty"`
 }
 
 type Thing_1 struct {
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }

--- a/tests/data/core/refOld.go.output
+++ b/tests/data/core/refOld.go.output
@@ -4,13 +4,13 @@ package test
 
 type RefOld struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 
 	// MyThing2 corresponds to the JSON schema field "myThing2".
-	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty"`
+	MyThing2 *Thing `json:"myThing2,omitempty" yaml:"myThing2,omitempty" mapstructure:"myThing2,omitempty"`
 }
 
 type Thing struct {
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }

--- a/tests/data/core/refToEnum.go.output
+++ b/tests/data/core/refToEnum.go.output
@@ -35,7 +35,7 @@ func (j *Thing) UnmarshalJSON(b []byte) error {
 
 type RefToEnum struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 }
 
 const ThingX Thing = "x"

--- a/tests/data/core/refToPrimitiveString.go.output
+++ b/tests/data/core/refToPrimitiveString.go.output
@@ -4,7 +4,7 @@ package test
 
 type RefToPrimitiveString struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty" mapstructure:"myThing,omitempty"`
 }
 
 type Thing string

--- a/tests/data/crossPackage/other.go.output
+++ b/tests/data/crossPackage/other.go.output
@@ -4,5 +4,5 @@ package other
 
 type Thing struct {
 	// S corresponds to the JSON schema field "s".
-	S *string `json:"s,omitempty" yaml:"s,omitempty"`
+	S *string `json:"s,omitempty" yaml:"s,omitempty" mapstructure:"s,omitempty"`
 }

--- a/tests/data/crossPackage/schema.go.output
+++ b/tests/data/crossPackage/schema.go.output
@@ -6,13 +6,13 @@ import other "github.com/example/other"
 
 type Schema struct {
 	// DefInOtherSchema corresponds to the JSON schema field "defInOtherSchema".
-	DefInOtherSchema *other.Thing `json:"defInOtherSchema,omitempty" yaml:"defInOtherSchema,omitempty"`
+	DefInOtherSchema *other.Thing `json:"defInOtherSchema,omitempty" yaml:"defInOtherSchema,omitempty" mapstructure:"defInOtherSchema,omitempty"`
 
 	// DefInSameSchema corresponds to the JSON schema field "defInSameSchema".
-	DefInSameSchema *Thing `json:"defInSameSchema,omitempty" yaml:"defInSameSchema,omitempty"`
+	DefInSameSchema *Thing `json:"defInSameSchema,omitempty" yaml:"defInSameSchema,omitempty" mapstructure:"defInSameSchema,omitempty"`
 }
 
 type Thing struct {
 	// S corresponds to the JSON schema field "s".
-	S *string `json:"s,omitempty" yaml:"s,omitempty"`
+	S *string `json:"s,omitempty" yaml:"s,omitempty" mapstructure:"s,omitempty"`
 }

--- a/tests/data/crossPackageNoOutput/schema.go.output
+++ b/tests/data/crossPackageNoOutput/schema.go.output
@@ -6,13 +6,13 @@ import other "github.com/example/other"
 
 type Schema struct {
 	// DefInOtherSchema corresponds to the JSON schema field "defInOtherSchema".
-	DefInOtherSchema *other.Thing `json:"defInOtherSchema,omitempty" yaml:"defInOtherSchema,omitempty"`
+	DefInOtherSchema *other.Thing `json:"defInOtherSchema,omitempty" yaml:"defInOtherSchema,omitempty" mapstructure:"defInOtherSchema,omitempty"`
 
 	// DefInSameSchema corresponds to the JSON schema field "defInSameSchema".
-	DefInSameSchema *Thing `json:"defInSameSchema,omitempty" yaml:"defInSameSchema,omitempty"`
+	DefInSameSchema *Thing `json:"defInSameSchema,omitempty" yaml:"defInSameSchema,omitempty" mapstructure:"defInSameSchema,omitempty"`
 }
 
 type Thing struct {
 	// S corresponds to the JSON schema field "s".
-	S *string `json:"s,omitempty" yaml:"s,omitempty"`
+	S *string `json:"s,omitempty" yaml:"s,omitempty" mapstructure:"s,omitempty"`
 }

--- a/tests/data/misc/boolean-as-schema.go.output
+++ b/tests/data/misc/boolean-as-schema.go.output
@@ -4,5 +4,5 @@ package test
 
 type BooleanAsSchema struct {
 	// Id corresponds to the JSON schema field "id".
-	Id *string `json:"id,omitempty" yaml:"id,omitempty"`
+	Id *string `json:"id,omitempty" yaml:"id,omitempty" mapstructure:"id,omitempty"`
 }

--- a/tests/data/misc/capitalization.go.output
+++ b/tests/data/misc/capitalization.go.output
@@ -4,38 +4,38 @@ package test
 
 type Capitalization struct {
 	// HtMl corresponds to the JSON schema field "html".
-	HtMl *string `json:"html,omitempty" yaml:"html,omitempty"`
+	HtMl *string `json:"html,omitempty" yaml:"html,omitempty" mapstructure:"html,omitempty"`
 
 	// HtMlSomethingElse corresponds to the JSON schema field "htmlSomethingElse".
-	HtMlSomethingElse *string `json:"htmlSomethingElse,omitempty" yaml:"htmlSomethingElse,omitempty"`
+	HtMlSomethingElse *string `json:"htmlSomethingElse,omitempty" yaml:"htmlSomethingElse,omitempty" mapstructure:"htmlSomethingElse,omitempty"`
 
 	// HtMl_2 corresponds to the JSON schema field "html__".
-	HtMl_2 *string `json:"html__,omitempty" yaml:"html__,omitempty"`
+	HtMl_2 *string `json:"html__,omitempty" yaml:"html__,omitempty" mapstructure:"html__,omitempty"`
 
 	// HtMlSomething corresponds to the JSON schema field "html_something".
-	HtMlSomething *string `json:"html_something,omitempty" yaml:"html_something,omitempty"`
+	HtMlSomething *string `json:"html_something,omitempty" yaml:"html_something,omitempty" mapstructure:"html_something,omitempty"`
 
 	// ID corresponds to the JSON schema field "id".
-	ID *string `json:"id,omitempty" yaml:"id,omitempty"`
+	ID *string `json:"id,omitempty" yaml:"id,omitempty" mapstructure:"id,omitempty"`
 
 	// IDSomethingElse corresponds to the JSON schema field "idSomethingElse".
-	IDSomethingElse *string `json:"idSomethingElse,omitempty" yaml:"idSomethingElse,omitempty"`
+	IDSomethingElse *string `json:"idSomethingElse,omitempty" yaml:"idSomethingElse,omitempty" mapstructure:"idSomethingElse,omitempty"`
 
 	// ID_2 corresponds to the JSON schema field "id__".
-	ID_2 *string `json:"id__,omitempty" yaml:"id__,omitempty"`
+	ID_2 *string `json:"id__,omitempty" yaml:"id__,omitempty" mapstructure:"id__,omitempty"`
 
 	// IDSomething corresponds to the JSON schema field "id_something".
-	IDSomething *string `json:"id_something,omitempty" yaml:"id_something,omitempty"`
+	IDSomething *string `json:"id_something,omitempty" yaml:"id_something,omitempty" mapstructure:"id_something,omitempty"`
 
 	// URL corresponds to the JSON schema field "url".
-	URL *string `json:"url,omitempty" yaml:"url,omitempty"`
+	URL *string `json:"url,omitempty" yaml:"url,omitempty" mapstructure:"url,omitempty"`
 
 	// URLSomethingElse corresponds to the JSON schema field "urlSomethingElse".
-	URLSomethingElse *string `json:"urlSomethingElse,omitempty" yaml:"urlSomethingElse,omitempty"`
+	URLSomethingElse *string `json:"urlSomethingElse,omitempty" yaml:"urlSomethingElse,omitempty" mapstructure:"urlSomethingElse,omitempty"`
 
 	// URL_2 corresponds to the JSON schema field "url__".
-	URL_2 *string `json:"url__,omitempty" yaml:"url__,omitempty"`
+	URL_2 *string `json:"url__,omitempty" yaml:"url__,omitempty" mapstructure:"url__,omitempty"`
 
 	// URLSomething corresponds to the JSON schema field "url_something".
-	URLSomething *string `json:"url_something,omitempty" yaml:"url_something,omitempty"`
+	URLSomething *string `json:"url_something,omitempty" yaml:"url_something,omitempty" mapstructure:"url_something,omitempty"`
 }

--- a/tests/data/miscWithDefaults/case.go.output
+++ b/tests/data/miscWithDefaults/case.go.output
@@ -4,20 +4,20 @@ package test
 
 type Case struct {
 	// CapitalCamelField corresponds to the JSON schema field "CapitalCamelField".
-	CapitalCamelField *string `json:"CapitalCamelField,omitempty" yaml:"CapitalCamelField,omitempty"`
+	CapitalCamelField *string `json:"CapitalCamelField,omitempty" yaml:"CapitalCamelField,omitempty" mapstructure:"CapitalCamelField,omitempty"`
 
 	// UPPERCASEFIELD corresponds to the JSON schema field "UPPERCASEFIELD".
-	UPPERCASEFIELD *string `json:"UPPERCASEFIELD,omitempty" yaml:"UPPERCASEFIELD,omitempty"`
+	UPPERCASEFIELD *string `json:"UPPERCASEFIELD,omitempty" yaml:"UPPERCASEFIELD,omitempty" mapstructure:"UPPERCASEFIELD,omitempty"`
 
 	// CamelCase corresponds to the JSON schema field "camelCase".
-	CamelCase *string `json:"camelCase,omitempty" yaml:"camelCase,omitempty"`
+	CamelCase *string `json:"camelCase,omitempty" yaml:"camelCase,omitempty" mapstructure:"camelCase,omitempty"`
 
 	// Lowercase corresponds to the JSON schema field "lowercase".
-	Lowercase *string `json:"lowercase,omitempty" yaml:"lowercase,omitempty"`
+	Lowercase *string `json:"lowercase,omitempty" yaml:"lowercase,omitempty" mapstructure:"lowercase,omitempty"`
 
 	// SnakeMixedCase corresponds to the JSON schema field "snake_Mixed_Case".
-	SnakeMixedCase *string `json:"snake_Mixed_Case,omitempty" yaml:"snake_Mixed_Case,omitempty"`
+	SnakeMixedCase *string `json:"snake_Mixed_Case,omitempty" yaml:"snake_Mixed_Case,omitempty" mapstructure:"snake_Mixed_Case,omitempty"`
 
 	// SnakeCase corresponds to the JSON schema field "snake_case".
-	SnakeCase *string `json:"snake_case,omitempty" yaml:"snake_case,omitempty"`
+	SnakeCase *string `json:"snake_case,omitempty" yaml:"snake_case,omitempty" mapstructure:"snake_case,omitempty"`
 }

--- a/tests/data/miscWithDefaults/caseDupes.go.output
+++ b/tests/data/miscWithDefaults/caseDupes.go.output
@@ -4,17 +4,17 @@ package test
 
 type CaseDupes struct {
 	// SomeField corresponds to the JSON schema field "SomeField".
-	SomeField *string `json:"SomeField,omitempty" yaml:"SomeField,omitempty"`
+	SomeField *string `json:"SomeField,omitempty" yaml:"SomeField,omitempty" mapstructure:"SomeField,omitempty"`
 
 	// SomeField_2 corresponds to the JSON schema field "someField".
-	SomeField_2 *string `json:"someField,omitempty" yaml:"someField,omitempty"`
+	SomeField_2 *string `json:"someField,omitempty" yaml:"someField,omitempty" mapstructure:"someField,omitempty"`
 
 	// SomeField_3 corresponds to the JSON schema field "some_Field".
-	SomeField_3 *string `json:"some_Field,omitempty" yaml:"some_Field,omitempty"`
+	SomeField_3 *string `json:"some_Field,omitempty" yaml:"some_Field,omitempty" mapstructure:"some_Field,omitempty"`
 
 	// SomeField_4 corresponds to the JSON schema field "some_field".
-	SomeField_4 *string `json:"some_field,omitempty" yaml:"some_field,omitempty"`
+	SomeField_4 *string `json:"some_field,omitempty" yaml:"some_field,omitempty" mapstructure:"some_field,omitempty"`
 
 	// Somefield corresponds to the JSON schema field "somefield".
-	Somefield *string `json:"somefield,omitempty" yaml:"somefield,omitempty"`
+	Somefield *string `json:"somefield,omitempty" yaml:"somefield,omitempty" mapstructure:"somefield,omitempty"`
 }

--- a/tests/data/miscWithDefaults/cyclic.go.output
+++ b/tests/data/miscWithDefaults/cyclic.go.output
@@ -4,15 +4,15 @@ package test
 
 type Bar struct {
 	// RefToFoo corresponds to the JSON schema field "refToFoo".
-	RefToFoo *Foo `json:"refToFoo,omitempty" yaml:"refToFoo,omitempty"`
+	RefToFoo *Foo `json:"refToFoo,omitempty" yaml:"refToFoo,omitempty" mapstructure:"refToFoo,omitempty"`
 }
 
 type Cyclic struct {
 	// A corresponds to the JSON schema field "a".
-	A *Foo `json:"a,omitempty" yaml:"a,omitempty"`
+	A *Foo `json:"a,omitempty" yaml:"a,omitempty" mapstructure:"a,omitempty"`
 }
 
 type Foo struct {
 	// RefToBar corresponds to the JSON schema field "refToBar".
-	RefToBar *Bar `json:"refToBar,omitempty" yaml:"refToBar,omitempty"`
+	RefToBar *Bar `json:"refToBar,omitempty" yaml:"refToBar,omitempty" mapstructure:"refToBar,omitempty"`
 }

--- a/tests/data/miscWithDefaults/cyclicAndRequired1.go.output
+++ b/tests/data/miscWithDefaults/cyclicAndRequired1.go.output
@@ -7,7 +7,7 @@ import "encoding/json"
 
 type Foo struct {
 	// RefToBar corresponds to the JSON schema field "refToBar".
-	RefToBar Bar `json:"refToBar" yaml:"refToBar"`
+	RefToBar Bar `json:"refToBar" yaml:"refToBar" mapstructure:"refToBar"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -30,10 +30,10 @@ func (j *Foo) UnmarshalJSON(b []byte) error {
 
 type Bar struct {
 	// RefToFoo corresponds to the JSON schema field "refToFoo".
-	RefToFoo *Foo `json:"refToFoo,omitempty" yaml:"refToFoo,omitempty"`
+	RefToFoo *Foo `json:"refToFoo,omitempty" yaml:"refToFoo,omitempty" mapstructure:"refToFoo,omitempty"`
 }
 
 type CyclicAndRequired1 struct {
 	// A corresponds to the JSON schema field "a".
-	A *Foo `json:"a,omitempty" yaml:"a,omitempty"`
+	A *Foo `json:"a,omitempty" yaml:"a,omitempty" mapstructure:"a,omitempty"`
 }

--- a/tests/data/miscWithDefaults/cyclicAndRequired2.go.output
+++ b/tests/data/miscWithDefaults/cyclicAndRequired2.go.output
@@ -7,7 +7,7 @@ import "encoding/json"
 
 type Foo struct {
 	// RefToBar corresponds to the JSON schema field "refToBar".
-	RefToBar Bar `json:"refToBar" yaml:"refToBar"`
+	RefToBar Bar `json:"refToBar" yaml:"refToBar" mapstructure:"refToBar"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -30,7 +30,7 @@ func (j *Foo) UnmarshalJSON(b []byte) error {
 
 type Bar struct {
 	// RefToFoo corresponds to the JSON schema field "refToFoo".
-	RefToFoo Foo `json:"refToFoo" yaml:"refToFoo"`
+	RefToFoo Foo `json:"refToFoo" yaml:"refToFoo" mapstructure:"refToFoo"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -53,5 +53,5 @@ func (j *Bar) UnmarshalJSON(b []byte) error {
 
 type CyclicAndRequired2 struct {
 	// A corresponds to the JSON schema field "a".
-	A *Foo `json:"a,omitempty" yaml:"a,omitempty"`
+	A *Foo `json:"a,omitempty" yaml:"a,omitempty" mapstructure:"a,omitempty"`
 }

--- a/tests/data/miscWithDefaults/rootEmptyJustDefinitions.go.output
+++ b/tests/data/miscWithDefaults/rootEmptyJustDefinitions.go.output
@@ -4,5 +4,5 @@ package test
 
 type Thing struct {
 	// Name corresponds to the JSON schema field "name".
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }

--- a/tests/data/validation/10.1_description.go.output
+++ b/tests/data/validation/10.1_description.go.output
@@ -6,8 +6,8 @@ package test
 type A101Description struct {
 	// MyDescriptionlessField corresponds to the JSON schema field
 	// "myDescriptionlessField".
-	MyDescriptionlessField *string `json:"myDescriptionlessField,omitempty" yaml:"myDescriptionlessField,omitempty"`
+	MyDescriptionlessField *string `json:"myDescriptionlessField,omitempty" yaml:"myDescriptionlessField,omitempty" mapstructure:"myDescriptionlessField,omitempty"`
 
 	// A string field.
-	MyField *string `json:"myField,omitempty" yaml:"myField,omitempty"`
+	MyField *string `json:"myField,omitempty" yaml:"myField,omitempty" mapstructure:"myField,omitempty"`
 }

--- a/tests/data/validation/5.10_maxItems.go.output
+++ b/tests/data/validation/5.10_maxItems.go.output
@@ -7,10 +7,10 @@ import "encoding/json"
 
 type A510MaxItems struct {
 	// MyNestedArray corresponds to the JSON schema field "myNestedArray".
-	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty"`
+	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty" mapstructure:"myNestedArray,omitempty"`
 
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
-	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty"`
+	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty" mapstructure:"myStringArray,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/5.11_minItems.go.output
+++ b/tests/data/validation/5.11_minItems.go.output
@@ -7,10 +7,10 @@ import "encoding/json"
 
 type A511MinItems struct {
 	// MyNestedArray corresponds to the JSON schema field "myNestedArray".
-	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty"`
+	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty" mapstructure:"myNestedArray,omitempty"`
 
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
-	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty"`
+	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty" mapstructure:"myStringArray,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/5.1x_minMaxItems.go.output
+++ b/tests/data/validation/5.1x_minMaxItems.go.output
@@ -7,10 +7,10 @@ import "encoding/json"
 
 type A51XMinMaxItems struct {
 	// MyNestedArray corresponds to the JSON schema field "myNestedArray".
-	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty"`
+	MyNestedArray [][]interface{} `json:"myNestedArray,omitempty" yaml:"myNestedArray,omitempty" mapstructure:"myNestedArray,omitempty"`
 
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
-	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty"`
+	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty" mapstructure:"myStringArray,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/6.1.1_typeMultiple.go.output
+++ b/tests/data/validation/6.1.1_typeMultiple.go.output
@@ -4,15 +4,15 @@ package test
 
 type A611TypeMultiple struct {
 	// All corresponds to the JSON schema field "all".
-	All interface{} `json:"all,omitempty" yaml:"all,omitempty"`
+	All interface{} `json:"all,omitempty" yaml:"all,omitempty" mapstructure:"all,omitempty"`
 
 	// AllPrimitives corresponds to the JSON schema field "allPrimitives".
-	AllPrimitives interface{} `json:"allPrimitives,omitempty" yaml:"allPrimitives,omitempty"`
+	AllPrimitives interface{} `json:"allPrimitives,omitempty" yaml:"allPrimitives,omitempty" mapstructure:"allPrimitives,omitempty"`
 
 	// ArrayOfAll corresponds to the JSON schema field "arrayOfAll".
-	ArrayOfAll []interface{} `json:"arrayOfAll,omitempty" yaml:"arrayOfAll,omitempty"`
+	ArrayOfAll []interface{} `json:"arrayOfAll,omitempty" yaml:"arrayOfAll,omitempty" mapstructure:"arrayOfAll,omitempty"`
 
 	// ArrayOfAllPrimitives corresponds to the JSON schema field
 	// "arrayOfAllPrimitives".
-	ArrayOfAllPrimitives []interface{} `json:"arrayOfAllPrimitives,omitempty" yaml:"arrayOfAllPrimitives,omitempty"`
+	ArrayOfAllPrimitives []interface{} `json:"arrayOfAllPrimitives,omitempty" yaml:"arrayOfAllPrimitives,omitempty" mapstructure:"arrayOfAllPrimitives,omitempty"`
 }

--- a/tests/data/validation/6.1.2_enum.go.output
+++ b/tests/data/validation/6.1.2_enum.go.output
@@ -8,38 +8,38 @@ import "encoding/json"
 
 type A612Enum struct {
 	// MyBooleanTypedEnum corresponds to the JSON schema field "myBooleanTypedEnum".
-	MyBooleanTypedEnum *A612EnumMyBooleanTypedEnum `json:"myBooleanTypedEnum,omitempty" yaml:"myBooleanTypedEnum,omitempty"`
+	MyBooleanTypedEnum *A612EnumMyBooleanTypedEnum `json:"myBooleanTypedEnum,omitempty" yaml:"myBooleanTypedEnum,omitempty" mapstructure:"myBooleanTypedEnum,omitempty"`
 
 	// MyBooleanUntypedEnum corresponds to the JSON schema field
 	// "myBooleanUntypedEnum".
-	MyBooleanUntypedEnum *A612EnumMyBooleanUntypedEnum `json:"myBooleanUntypedEnum,omitempty" yaml:"myBooleanUntypedEnum,omitempty"`
+	MyBooleanUntypedEnum *A612EnumMyBooleanUntypedEnum `json:"myBooleanUntypedEnum,omitempty" yaml:"myBooleanUntypedEnum,omitempty" mapstructure:"myBooleanUntypedEnum,omitempty"`
 
 	// MyIntegerTypedEnum corresponds to the JSON schema field "myIntegerTypedEnum".
-	MyIntegerTypedEnum *A612EnumMyIntegerTypedEnum `json:"myIntegerTypedEnum,omitempty" yaml:"myIntegerTypedEnum,omitempty"`
+	MyIntegerTypedEnum *A612EnumMyIntegerTypedEnum `json:"myIntegerTypedEnum,omitempty" yaml:"myIntegerTypedEnum,omitempty" mapstructure:"myIntegerTypedEnum,omitempty"`
 
 	// MyMixedTypeEnum corresponds to the JSON schema field "myMixedTypeEnum".
-	MyMixedTypeEnum *A612EnumMyMixedTypeEnum `json:"myMixedTypeEnum,omitempty" yaml:"myMixedTypeEnum,omitempty"`
+	MyMixedTypeEnum *A612EnumMyMixedTypeEnum `json:"myMixedTypeEnum,omitempty" yaml:"myMixedTypeEnum,omitempty" mapstructure:"myMixedTypeEnum,omitempty"`
 
 	// MyMixedUntypedEnum corresponds to the JSON schema field "myMixedUntypedEnum".
-	MyMixedUntypedEnum *A612EnumMyMixedUntypedEnum `json:"myMixedUntypedEnum,omitempty" yaml:"myMixedUntypedEnum,omitempty"`
+	MyMixedUntypedEnum *A612EnumMyMixedUntypedEnum `json:"myMixedUntypedEnum,omitempty" yaml:"myMixedUntypedEnum,omitempty" mapstructure:"myMixedUntypedEnum,omitempty"`
 
 	// MyNullTypedEnum corresponds to the JSON schema field "myNullTypedEnum".
-	MyNullTypedEnum *A612EnumMyNullTypedEnum `json:"myNullTypedEnum,omitempty" yaml:"myNullTypedEnum,omitempty"`
+	MyNullTypedEnum *A612EnumMyNullTypedEnum `json:"myNullTypedEnum,omitempty" yaml:"myNullTypedEnum,omitempty" mapstructure:"myNullTypedEnum,omitempty"`
 
 	// MyNullUntypedEnum corresponds to the JSON schema field "myNullUntypedEnum".
-	MyNullUntypedEnum *A612EnumMyNullUntypedEnum `json:"myNullUntypedEnum,omitempty" yaml:"myNullUntypedEnum,omitempty"`
+	MyNullUntypedEnum *A612EnumMyNullUntypedEnum `json:"myNullUntypedEnum,omitempty" yaml:"myNullUntypedEnum,omitempty" mapstructure:"myNullUntypedEnum,omitempty"`
 
 	// MyNumberTypedEnum corresponds to the JSON schema field "myNumberTypedEnum".
-	MyNumberTypedEnum *A612EnumMyNumberTypedEnum `json:"myNumberTypedEnum,omitempty" yaml:"myNumberTypedEnum,omitempty"`
+	MyNumberTypedEnum *A612EnumMyNumberTypedEnum `json:"myNumberTypedEnum,omitempty" yaml:"myNumberTypedEnum,omitempty" mapstructure:"myNumberTypedEnum,omitempty"`
 
 	// MyNumberUntypedEnum corresponds to the JSON schema field "myNumberUntypedEnum".
-	MyNumberUntypedEnum *A612EnumMyNumberUntypedEnum `json:"myNumberUntypedEnum,omitempty" yaml:"myNumberUntypedEnum,omitempty"`
+	MyNumberUntypedEnum *A612EnumMyNumberUntypedEnum `json:"myNumberUntypedEnum,omitempty" yaml:"myNumberUntypedEnum,omitempty" mapstructure:"myNumberUntypedEnum,omitempty"`
 
 	// MyStringTypedEnum corresponds to the JSON schema field "myStringTypedEnum".
-	MyStringTypedEnum *A612EnumMyStringTypedEnum `json:"myStringTypedEnum,omitempty" yaml:"myStringTypedEnum,omitempty"`
+	MyStringTypedEnum *A612EnumMyStringTypedEnum `json:"myStringTypedEnum,omitempty" yaml:"myStringTypedEnum,omitempty" mapstructure:"myStringTypedEnum,omitempty"`
 
 	// MyStringUntypedEnum corresponds to the JSON schema field "myStringUntypedEnum".
-	MyStringUntypedEnum *A612EnumMyStringUntypedEnum `json:"myStringUntypedEnum,omitempty" yaml:"myStringUntypedEnum,omitempty"`
+	MyStringUntypedEnum *A612EnumMyStringUntypedEnum `json:"myStringUntypedEnum,omitempty" yaml:"myStringUntypedEnum,omitempty" mapstructure:"myStringUntypedEnum,omitempty"`
 }
 
 type A612EnumMyBooleanTypedEnum bool

--- a/tests/data/validation/6.5.3_requiredFields.go.output
+++ b/tests/data/validation/6.5.3_requiredFields.go.output
@@ -8,7 +8,7 @@ import "encoding/json"
 type A653RequiredFieldsMyObject struct {
 	// MyNestedObjectString corresponds to the JSON schema field
 	// "myNestedObjectString".
-	MyNestedObjectString string `json:"myNestedObjectString" yaml:"myNestedObjectString"`
+	MyNestedObjectString string `json:"myNestedObjectString" yaml:"myNestedObjectString" mapstructure:"myNestedObjectString"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -32,7 +32,7 @@ func (j *A653RequiredFieldsMyObject) UnmarshalJSON(b []byte) error {
 type A653RequiredFieldsMyObjectArrayElem struct {
 	// MyNestedObjectString corresponds to the JSON schema field
 	// "myNestedObjectString".
-	MyNestedObjectString string `json:"myNestedObjectString" yaml:"myNestedObjectString"`
+	MyNestedObjectString string `json:"myNestedObjectString" yaml:"myNestedObjectString" mapstructure:"myNestedObjectString"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -55,40 +55,40 @@ func (j *A653RequiredFieldsMyObjectArrayElem) UnmarshalJSON(b []byte) error {
 
 type A653RequiredFields struct {
 	// MyBoolean corresponds to the JSON schema field "myBoolean".
-	MyBoolean bool `json:"myBoolean" yaml:"myBoolean"`
+	MyBoolean bool `json:"myBoolean" yaml:"myBoolean" mapstructure:"myBoolean"`
 
 	// MyBooleanArray corresponds to the JSON schema field "myBooleanArray".
-	MyBooleanArray []bool `json:"myBooleanArray" yaml:"myBooleanArray"`
+	MyBooleanArray []bool `json:"myBooleanArray" yaml:"myBooleanArray" mapstructure:"myBooleanArray"`
 
 	// MyInteger corresponds to the JSON schema field "myInteger".
-	MyInteger *int `json:"myInteger,omitempty" yaml:"myInteger,omitempty"`
+	MyInteger *int `json:"myInteger,omitempty" yaml:"myInteger,omitempty" mapstructure:"myInteger,omitempty"`
 
 	// MyIntegerArray corresponds to the JSON schema field "myIntegerArray".
-	MyIntegerArray []int `json:"myIntegerArray,omitempty" yaml:"myIntegerArray,omitempty"`
+	MyIntegerArray []int `json:"myIntegerArray,omitempty" yaml:"myIntegerArray,omitempty" mapstructure:"myIntegerArray,omitempty"`
 
 	// MyNull corresponds to the JSON schema field "myNull".
-	MyNull interface{} `json:"myNull" yaml:"myNull"`
+	MyNull interface{} `json:"myNull" yaml:"myNull" mapstructure:"myNull"`
 
 	// MyNullArray corresponds to the JSON schema field "myNullArray".
-	MyNullArray []interface{} `json:"myNullArray" yaml:"myNullArray"`
+	MyNullArray []interface{} `json:"myNullArray" yaml:"myNullArray" mapstructure:"myNullArray"`
 
 	// MyNumber corresponds to the JSON schema field "myNumber".
-	MyNumber float64 `json:"myNumber" yaml:"myNumber"`
+	MyNumber float64 `json:"myNumber" yaml:"myNumber" mapstructure:"myNumber"`
 
 	// MyNumberArray corresponds to the JSON schema field "myNumberArray".
-	MyNumberArray []float64 `json:"myNumberArray" yaml:"myNumberArray"`
+	MyNumberArray []float64 `json:"myNumberArray" yaml:"myNumberArray" mapstructure:"myNumberArray"`
 
 	// MyObject corresponds to the JSON schema field "myObject".
-	MyObject A653RequiredFieldsMyObject `json:"myObject" yaml:"myObject"`
+	MyObject A653RequiredFieldsMyObject `json:"myObject" yaml:"myObject" mapstructure:"myObject"`
 
 	// MyObjectArray corresponds to the JSON schema field "myObjectArray".
-	MyObjectArray []A653RequiredFieldsMyObjectArrayElem `json:"myObjectArray" yaml:"myObjectArray"`
+	MyObjectArray []A653RequiredFieldsMyObjectArrayElem `json:"myObjectArray" yaml:"myObjectArray" mapstructure:"myObjectArray"`
 
 	// MyString corresponds to the JSON schema field "myString".
-	MyString string `json:"myString" yaml:"myString"`
+	MyString string `json:"myString" yaml:"myString" mapstructure:"myString"`
 
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
-	MyStringArray []string `json:"myStringArray" yaml:"myStringArray"`
+	MyStringArray []string `json:"myStringArray" yaml:"myStringArray" mapstructure:"myStringArray"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/typed_default.go.output
+++ b/tests/data/validation/typed_default.go.output
@@ -6,7 +6,7 @@ import "encoding/json"
 
 type TypedDefault struct {
 	// TopLevelDomains corresponds to the JSON schema field "topLevelDomains".
-	TopLevelDomains []string `json:"topLevelDomains,omitempty" yaml:"topLevelDomains,omitempty"`
+	TopLevelDomains []string `json:"topLevelDomains,omitempty" yaml:"topLevelDomains,omitempty" mapstructure:"topLevelDomains,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/typed_default_empty.go.output
+++ b/tests/data/validation/typed_default_empty.go.output
@@ -6,7 +6,7 @@ import "encoding/json"
 
 type TypedDefaultEmpty struct {
 	// TopLevelDomains corresponds to the JSON schema field "topLevelDomains".
-	TopLevelDomains []string `json:"topLevelDomains,omitempty" yaml:"topLevelDomains,omitempty"`
+	TopLevelDomains []string `json:"topLevelDomains,omitempty" yaml:"topLevelDomains,omitempty" mapstructure:"topLevelDomains,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/tests/data/validation/typed_default_enums.go.output
+++ b/tests/data/validation/typed_default_enums.go.output
@@ -35,7 +35,7 @@ func (j *TypedDefaultEnumsSome) UnmarshalJSON(b []byte) error {
 
 type TypedDefaultEnums struct {
 	// Some corresponds to the JSON schema field "some".
-	Some TypedDefaultEnumsSome `json:"some,omitempty" yaml:"some,omitempty"`
+	Some TypedDefaultEnumsSome `json:"some,omitempty" yaml:"some,omitempty" mapstructure:"some,omitempty"`
 }
 
 const TypedDefaultEnumsSomeOther TypedDefaultEnumsSome = "other"

--- a/tests/data/yaml/yamlMultilineDescriptions.go.output
+++ b/tests/data/yaml/yamlMultilineDescriptions.go.output
@@ -9,9 +9,9 @@ type YamlMultilineDescriptions struct {
 	//
 	// This may look funky when Go code is generated to a specific line width, though.
 	//
-	Bar *string `json:"bar,omitempty" yaml:"bar,omitempty"`
+	Bar *string `json:"bar,omitempty" yaml:"bar,omitempty" mapstructure:"bar,omitempty"`
 
 	// I'm a multiline description in a folded block. Folded blocks should not have
 	// hard line breaks after parsing. They should also not end in a line break.
-	Foo *string `json:"foo,omitempty" yaml:"foo,omitempty"`
+	Foo *string `json:"foo,omitempty" yaml:"foo,omitempty" mapstructure:"foo,omitempty"`
 }

--- a/tests/data/yaml/yamlStructNameFromFile.go.output
+++ b/tests/data/yaml/yamlStructNameFromFile.go.output
@@ -4,5 +4,5 @@ package test
 
 type YamlStructNameFromFile struct {
 	// Foo corresponds to the JSON schema field "foo".
-	Foo *string `json:"foo,omitempty" yaml:"foo,omitempty"`
+	Foo *string `json:"foo,omitempty" yaml:"foo,omitempty" mapstructure:"foo,omitempty"`
 }


### PR DESCRIPTION
Added `mapstructure` field tag, to allow using generated structures in scenarios, when `viper.Unmarshal()` fails, due to wrongly tagged fields.